### PR TITLE
Handle table of contents not on top level

### DIFF
--- a/markdown-include.js
+++ b/markdown-include.js
@@ -25,32 +25,30 @@ this.customTags = [];
  * @return {String}     String for markdown navigation item
  */
 exports.buildContentItem = function (obj) {
-	var headingTag = obj.headingTag;
 	var count = obj.count;
-	var item = headingTag.substring(count + 1);
-	var index = headingTag.indexOf(item);
-	var headingTrimmed = this.buildLinkString(headingTag.substring(index));
+	var item = obj.item;
+	var itemLink = this.buildLinkString(item);
 	var lead = this.options.tableOfContents.lead && this.options.tableOfContents.lead === 'number' ? '1.' : '*';
 	var navItem;
 
-	switch (obj.count) {
+	switch (count) {
 		case 1:
-			navItem = lead + ' ' + this.buildLink(item, headingTrimmed);
+			navItem = lead + ' ' + this.buildLink(item, itemLink);
 		break;
 		case 2:
-			navItem = '  ' + lead + ' ' + this.buildLink(item, headingTrimmed);
+			navItem = '  ' + lead + ' ' + this.buildLink(item, itemLink);
 		break;
 		case 3:
-			navItem = '    ' + lead + ' ' + this.buildLink(item, headingTrimmed);
+			navItem = '    ' + lead + ' ' + this.buildLink(item, itemLink);
 		break;
 		case 4:
-			navItem = '      ' + lead + ' ' + this.buildLink(item, headingTrimmed);
+			navItem = '      ' + lead + ' ' + this.buildLink(item, itemLink);
 		break;
 		case 5:
-			navItem = '        ' + lead + ' ' + this.buildLink(item, headingTrimmed);
+			navItem = '        ' + lead + ' ' + this.buildLink(item, itemLink);
 		break;
 		case 6:
-			navItem = '          ' + lead + ' ' + this.buildLink(item, headingTrimmed);
+			navItem = '          ' + lead + ' ' + this.buildLink(item, itemLink);
 		break;
 	}
 
@@ -167,13 +165,18 @@ exports.compileFiles = function (path) {
 exports.compileHeadingTags = function (file) {
 	var headingTags = this.findHeadingTags(this.build[file].parsedData);
 	var replacedHeadingTag;
-	var parsedHeading;
+	var parsedHeadings = [];
 	var i;
 
 	for (i = 0; i < headingTags.length; i += 1) {
 		replacedHeadingTag = headingTags[i].replace(this.headingTag, '');
-		parsedHeading = this.parseHeadingTag(replacedHeadingTag);
-		this.tableOfContents += this.buildContentItem(parsedHeading);
+		parsedHeadings.push(this.parseHeadingTag(replacedHeadingTag));
+	}
+	var minCount = this.getMinCount(parsedHeadings);
+
+	for (i = 0; i < parsedHeadings.length; i += 1) {
+		parsedHeadings[i].count = parsedHeadings[i].count - minCount + 1;
+		this.tableOfContents += this.buildContentItem(parsedHeadings[i]);
 	}
 
 	this.build[file].parsedData = this.stripTagsInFile({
@@ -182,6 +185,17 @@ exports.compileHeadingTags = function (file) {
 		string: this.headingTag
 	});
 };
+
+exports.getMinCount = function getMinCount(parsedHeadings) {
+	var minCount = 0;
+	for (var i = 0; i < parsedHeadings.length; i += 1) {
+		var count = parsedHeadings[i].count;
+		if (minCount === 0 || count < minCount) {
+			minCount = count;
+		}
+	}
+	return minCount;
+}
 
 /**
  * Finding heading tags that have !heading
@@ -228,6 +242,7 @@ exports.findIncludeTags = function (rawData) {
  */
 exports.parseHeadingTag = function (headingTag) {
 	var count = 0;
+	var item;
 	var i;
 
 	for (i = 0; i < headingTag.length; i += 1) {
@@ -235,6 +250,7 @@ exports.parseHeadingTag = function (headingTag) {
 			count += 1;
 		}
 		else {
+			item = headingTag.slice(count + 1);
 			break;
 		}
 	}
@@ -242,7 +258,8 @@ exports.parseHeadingTag = function (headingTag) {
 	// Do we need to return the heading tag??
 	return {
 		count: count,
-		headingTag: headingTag
+		headingTag: headingTag,
+		item: item
 	};
 };
 

--- a/tests/all.js
+++ b/tests/all.js
@@ -1,6 +1,7 @@
 /* eslint-env amd */
 define([
 	'./unit/buildContentItem',
+	'./unit/buildTableOfContents',
 	'./unit/buildLinkString',
 	'./unit/compileFiles',
 	'./unit/compileHeadingTags',

--- a/tests/data/docs/has_heading_tags_on_lower_levels.md
+++ b/tests/data/docs/has_heading_tags_on_lower_levels.md
@@ -1,0 +1,6 @@
+# First Test Heading
+## Second Test Heading
+### Third Test Heading !heading
+#### Fourth Test Heading !heading
+##### Fifth Test Heading !heading
+###### Sixth Test Heading !heading

--- a/tests/unit/buildContentItem.js
+++ b/tests/unit/buildContentItem.js
@@ -17,7 +17,8 @@ define([
 
 			var contentItem = markdownInclude.buildContentItem({
 				count: 1,
-				headingTag: '# My Heading To Link'
+				headingTag: '# My Heading To Link',
+				item: 'My Heading To Link'
 			});
 
 			assert.equal(contentItem, '1. [My Heading To Link](#my-heading-to-link)\n', 'Content items match');
@@ -32,7 +33,8 @@ define([
 
 			var contentItem = markdownInclude.buildContentItem({
 				count: 1,
-				headingTag: '# My Heading To Link'
+				headingTag: '# My Heading To Link',
+				item: 'My Heading To Link'
 			});
 
 			assert.equal(contentItem, '* [My Heading To Link](#my-heading-to-link)\n', 'Content items match');

--- a/tests/unit/buildTableOfContents.js
+++ b/tests/unit/buildTableOfContents.js
@@ -1,0 +1,34 @@
+define([
+	'intern!bdd',
+	'intern/chai!assert',
+	'intern/dojo/node!../../markdown-include'
+], function (bdd, assert, markdownInclude) {
+	bdd.describe('markdownInclude.buildTableOfContents', function () {
+		bdd.after(function () {
+			markdownInclude.options = markdownInclude.build = {};
+			markdownInclude.tableOfContents = '';
+		});
+
+		bdd.beforeEach(function () {
+			markdownInclude.options = {
+				tableOfContents: {
+					lead: 'number'
+				}
+			};
+			markdownInclude.tableOfContents = '';
+
+			markdownInclude.processFile('tests/data/docs/has_heading_tags_on_lower_levels.md');
+		});
+
+		bdd.it('should create a table of contents with correct level', function () {
+			markdownInclude.compileHeadingTags('tests/data/docs/has_heading_tags_on_lower_levels.md');
+
+			assert.equal(markdownInclude.tableOfContents,
+				'1. [Third Test Heading](#third-test-heading)\n' +
+				'  1. [Fourth Test Heading](#fourth-test-heading)\n' +
+				'    1. [Fifth Test Heading](#fifth-test-heading)\n' +
+				'      1. [Sixth Test Heading](#sixth-test-heading)\n',
+				'Data matches');
+		});
+	});
+});

--- a/tests/unit/parseHeadingTag.js
+++ b/tests/unit/parseHeadingTag.js
@@ -8,5 +8,9 @@ define([
 			var count = markdownInclude.parseHeadingTag('### heading').count;
 			assert.equal(count, 3, 'Counts match');
 		});
+		bdd.it('should return the item string from a heading tag', function () {
+			var item = markdownInclude.parseHeadingTag('### heading').item;
+			assert.equal(item, 'heading', 'Item match');
+		});
 	});
 });


### PR DESCRIPTION
Table of contents are now correctly generated even if the top level
headings are not included with the "!heading" marker.

Fixes #18